### PR TITLE
Using go's builtin UserConfigDirectory

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -111,19 +111,25 @@ func errorHandling() {
 }
 
 func initConfig() {
-	// Find home directory.
-	homeDirectory, err := os.UserHomeDir()
-	if err != nil {
-		panic(exceptions.CheatException("Could not find home directory", err))
-	}
+	// Find config/home directory.
+	configrc, err := os.UserConfigDir()
+    if err != nil {
+        configrc, err = os.UserHomeDir()
+        if err != nil {
+	    	panic(exceptions.CheatException("Could not find home directory", err))
+	    }
+        configrc += "/.cheat/"
+    } else {
+        configrc += "/cheat/"
+    }
 
-	// Search config in home directory with name ".cheet" (without extension).
-	viper.AddConfigPath(homeDirectory)
-	viper.SetConfigName(".cheet")
+	// Search cheat folder in home or config directory and file name "cheatrc"
+    viper.AddConfigPath(configrc)
+	viper.SetConfigName("cheatrc")
 
 	// Fallback to "vi" for the editor
 	viper.SetDefault("editor", utils.GetEnv("EDITOR", "vi"))
-	viper.SetDefault("database", "~/.cheetsheet.db")
+	viper.SetDefault("database", "~/.cheatsheet.db")
 
 	// Load config
 	_ = viper.ReadInConfig()

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -111,15 +111,21 @@ func errorHandling() {
 }
 
 func initConfig() {
-	// Find home directory.
-	homeDirectory, err := os.UserHomeDir()
-	if err != nil {
-		panic(exceptions.CheatException("Could not find home directory", err))
-	}
+	// Find config/home directory.
+	configrc, err := os.UserConfigDir()
+    if err != nil {
+        configrc, err = os.UserHomeDir()
+        if err != nil {
+	    	panic(exceptions.CheatException("Could not find home directory", err))
+	    }
+        configrc += "/.cheat/"
+    } else {
+        configrc += "/cheat/"
+    }
 
-	// Search config in home directory with name ".cheat" (without extension).
-	viper.AddConfigPath(homeDirectory)
-	viper.SetConfigName(".cheat")
+	// Search cheat folder in home or config directory and file name "cheatrc"
+    viper.AddConfigPath(configrc)
+	viper.SetConfigName("cheatrc")
 
 	// Fallback to "vi" for the editor
 	viper.SetDefault("editor", utils.GetEnv("EDITOR", "vi"))


### PR DESCRIPTION
This small patch searches firstly for user's config directory, e.g. in
linnux that is XDG_CONFIG_DIR and if not fond moves to placing config
files into $HOME directory. I believe this is important to not clutter
the $HOME directory.